### PR TITLE
Fixed bug in checksum when entropy is more than 256 bits

### DIFF
--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -62,8 +62,8 @@ var Mnemonic = function(data, wordlist) {
   if (phrase && !Mnemonic.isValid(phrase, wordlist)) {
     throw new errors.Mnemonic.InvalidMnemonic(phrase);
   }
-  if (ent % 32 !== 0 || ent < 128 || ent > 256) {
-    throw new errors.InvalidArgument('ENT', 'Values must be 128 < ENT < 256 and ENT % 32 == 0');
+  if (ent % 32 !== 0 || ent < 128) {
+    throw new errors.InvalidArgument('ENT', 'Values must be ENT > 128 and ENT % 32 == 0');
   }
 
   phrase = phrase || Mnemonic._mnemonic(ent, wordlist);

--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -115,9 +115,7 @@ Mnemonic.isValid = function(mnemonic, wordlist) {
   for (var i = 0; i < nonhash_bits.length / 8; i++) {
     buf.writeUInt8(parseInt(bin.slice(i * 8, (i + 1) * 8), 2), i);
   }
-  var hash = Hash.sha256(buf);
-  var expected_hash_bits = hash[0].toString(2);
-  expected_hash_bits = ("00000000" + expected_hash_bits).slice(-8).slice(0, cs);
+  var expected_hash_bits = Mnemonic._entropyChecksum(buf);
   return expected_hash_bits === hash_bits;
 };
 
@@ -212,15 +210,12 @@ Mnemonic._mnemonic = function(ENT, wordlist) {
  * @returns {String} Mnemonic string
  */
 Mnemonic._entropy2mnemonic = function(entropy, wordlist) {
-  var hash = Hash.sha256(entropy);
   var bin = "";
-  var bits = entropy.length * 8;
   for (var i = 0; i < entropy.length; i++) {
     bin = bin + ("00000000" + entropy[i].toString(2)).slice(-8);
   }
-  var hashbits = hash[0].toString(2);
-  hashbits = ("00000000" + hashbits).slice(-8).slice(0, bits / 32);
-  bin = bin + hashbits;
+
+  bin = bin + Mnemonic._entropyChecksum(entropy);
   if (bin.length % 11 != 0) {
     throw new errors.Mnemonic.InvalidEntropy(bin);
   }
@@ -230,6 +225,25 @@ Mnemonic._entropy2mnemonic = function(entropy, wordlist) {
     mnemonic.push(wordlist[wi]);
   }
   return mnemonic.join(" ");
+};
+
+/**
+ * Internal function to create checksum of entropy
+ *
+ * @param entropy
+ * @returns {string} Checksum of entropy length / 32
+ * @private
+ */
+Mnemonic._entropyChecksum = function(entropy) {
+  var hash = Hash.sha256(entropy);
+  var bits = entropy.length * 8;
+  var cs = bits / 32;
+
+  var hashbits = parseInt(hash.toString('hex'), 16).toString(2);
+  // zero pad the hash bits
+  hashbits = (new Array(256).join("0") + hashbits).slice(-256).slice(0, cs);
+
+  return hashbits;
 };
 
 module.exports = Mnemonic;

--- a/test/mnemonic.unit.js
+++ b/test/mnemonic.unit.js
@@ -14,6 +14,9 @@ describe('Mnemonic', function() {
   // From python reference code, formatting unchanged
   var bip39_vectors = {
       "english": [
+        /*
+         * official english test vectors from BIP39 spec
+         */
           [
           "00000000000000000000000000000000",
           "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
@@ -133,8 +136,16 @@ describe('Mnemonic', function() {
               "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
           "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
           "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
+              ],
+        /*
+         * extra test vector to highlight bug in checksum with 512 bit entropy
+         */
+          [
+              "38fe1937dd2135d7ca5e472565c41ded449d8cea2e70e1c93571c21831c82f0f466c3d94f29bff1d0cce3e85a22b93364627af716ee91a477d6e2e55abf4e761",
+          "decline valid evil ripple battle typical city similar century comfort alter surround endorse shoe post sock tide endless fragile loud loan tomato rotate trip history uncover device dawn vault major decline spawn peasant frame snow middle kit reward roof cash electric twin merit prize satisfy inhale lyrics lucky",
+          "d9a9b65c54df4104349d5ce6f9275f249160ddf378deff6e540f5492e449e0378ee20b1622bef982f6dddb003568e449fee66335cb45cbe3f8a41050b251238a"
               ]
-          ]
+      ]
   }
 
   it('should initialize the class', function() {


### PR DESCRIPTION
the hash is sliced and zero padded in such a way that it will only work for entropy up to 256 bits (a checksum of max 8 bits).

PR in 2 parts; first a failing test and then a fix