### PR TITLE
Fix a bug in Mnemonic._entropyChecksum

### DIFF
--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -274,11 +274,10 @@ Mnemonic._entropyChecksum = function(entropy) {
   var bits = entropy.length * 8;
   var cs = bits / 32;
 
-  var hashbits = parseInt(hash.toString('hex'), 16).toString(2);
   // zero pad the hash bits
-  hashbits = (new Array(256).join('0') + hashbits).slice(-256).slice(0, cs);
-
-  return hashbits;
+  var paddedHash = new Array(256).join('0') + hash.toString('hex');
+  var hashbits = paddedHash.slice(-64).slice(0, cs / 4);
+  return parseInt(hashbits, 16).toString(2);
 };
 
 module.exports = Mnemonic;


### PR DESCRIPTION
The result of toString on a number can be different across browsers for large numbers. In particular, it's possible for IE to use exponential notation, which was breaking Mnemonic._entropyChecksum.

This can be reproduced using this seed: `patrol wise idea oyster inquiry crash dignity chronic scatter time admit pet`, which is valid on Chrome and Firefox, but invalid on IE11 and Edge.