### PR TITLE
[BUGFIX] Fix major utf8 bug

### DIFF
--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -24,6 +24,10 @@ function pbkdf2(key, salt, iterations, dkLen) {
     throw new TypeError('salt must a string or Buffer');
   }
 
+  if (typeof key === 'string') {
+    key = new Buffer(key);
+  }
+
   if (typeof salt === 'string') {
     salt = new Buffer(salt);
   }


### PR DESCRIPTION
The bug currently causes all non-ascii mnemonic/salts to deviate from other libraries (as seen in my Add jp tests pull request)

This is dependent on the environment of the user, which is why Copay is working but my node client is not.

Copay interprets the Japanese as UTF8 bytes after normalization.
However, my system is using codepage 932 (shift-jis) so even after running through unorm, my system generates shift-jis bytes of the normalized string instead of utf8...

using Buffer to convert to utf8 bytes will guarantee that it is used in the pbkdf as utf8 bytes.