### PR TITLE
Expose bitcore-lib

### DIFF
--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -292,4 +292,6 @@ Mnemonic._entropyChecksum = function(entropy) {
   return checksum;
 };
 
+Mnemonic.bitcore = bitcore;
+
 module.exports = Mnemonic;


### PR DESCRIPTION
requiring bitcore-lib after bitcore-mnemonic causes errors for loading more than one bitcore-lib.

This will allow users to access the bitcore-lib used by mnemonic.