### PR TITLE
Set upper limit on entropy as per revised BIP39 spec

### DIFF
--- a/lib/mnemonic.js
+++ b/lib/mnemonic.js
@@ -50,6 +50,7 @@ var Mnemonic = function(data, wordlist) {
   var ent, phrase, seed;
   if (Buffer.isBuffer(data)) {
     seed = data;
+    ent = seed.length * 8;
   } else if (_.isString(data)) {
     phrase = unorm.nfkd(data);
   } else if (_.isNumber(data)) {
@@ -76,8 +77,8 @@ var Mnemonic = function(data, wordlist) {
   if (phrase && !Mnemonic.isValid(phrase, wordlist)) {
     throw new errors.InvalidMnemonic(phrase);
   }
-  if (ent % 32 !== 0 || ent < 128) {
-    throw new bitcore.errors.InvalidArgument('ENT', 'Values must be ENT > 128 and ENT % 32 == 0');
+  if (ent % 32 !== 0 || ent < 128 || ent > 256) {
+    throw new bitcore.errors.InvalidArgument('ENT', 'Values must be ENT > 128 and ENT < 256 and ENT % 32 == 0');
   }
 
   phrase = phrase || Mnemonic._mnemonic(ent, wordlist);

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -143,12 +143,6 @@
        "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
        "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
        "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
-     ],
-     [
-       "TREZOR",
-       "38fe1937dd2135d7ca5e472565c41ded449d8cea2e70e1c93571c21831c82f0f466c3d94f29bff1d0cce3e85a22b93364627af716ee91a477d6e2e55abf4e761",
-       "decline valid evil ripple battle typical city similar century comfort alter surround endorse shoe post sock tide endless fragile loud loan tomato rotate trip history uncover device dawn vault major decline spawn peasant frame snow middle kit reward roof cash electric twin merit prize satisfy inhale lyrics lucky",
-       "d9a9b65c54df4104349d5ce6f9275f249160ddf378deff6e540f5492e449e0378ee20b1622bef982f6dddb003568e449fee66335cb45cbe3f8a41050b251238a"
      ]
    ],
    "japanese": [

--- a/test/mnemonic.unit.js
+++ b/test/mnemonic.unit.js
@@ -176,6 +176,12 @@ describe('Mnemonic', function() {
       }).should.throw(errors.InvalidArgument);
     });
 
+    it('should fail with invalid entropy', function() {
+      (function() {
+        return Mnemonic.fromSeed(Buffer.alloc(512), Mnemonic.Words.ENGLISH);
+      }).should.throw(errors.InvalidArgument);
+    });
+
     it('Constructor should fail with invalid seed', function() {
       (function() {
         return new Mnemonic(new Buffer(1));


### PR DESCRIPTION
https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic

> The allowed size of ENT is 128-256 bits. 

The last step should not be allowed as stated in the revised BIP39 spec
```
var mnemonic = new Mnemonic(256, Mnemonic.Words.ENGLISH);
var seed = mnemonic.toSeed("password");
var derivedFrom512BitEntropyMnemonicWith48Words = Mnemonic.fromSeed(seed, Mnemonic.Words.ENGLISH);
````